### PR TITLE
Add redirect based on user's admin status

### DIFF
--- a/src/components/login/LoginForm.component.jsx
+++ b/src/components/login/LoginForm.component.jsx
@@ -39,6 +39,12 @@ export default function LoginForm({ loginType }) {
 
         try {
             const userExists = handleLoginAction(username, password);
+            if (userExists.isAdmin) {
+                window.location.href = `/student-portal-all-programs`;
+                //TODO: Redirect to the admin-portal-all-programs page after page is created
+            } else {
+                window.location.href = `/student-portal-dashboard/${username}`;
+            }
 
             if (!userExists) {
                 setToastState(oldState => ({


### PR DESCRIPTION
This pull request adds a redirect feature based on whether the user is an admin or not. If the user is an admin, they will be redirected to the "admin-portal-all-programs" page (TODO: page creation pending). If the user is not an admin, they will be redirected to the "student-portal-dashboard" page with their username as a parameter.