### PR TITLE
Remove profile option from navigation bar

### DIFF
--- a/frontend/src/components/student-portal/nav-bar/NavBar.Component.jsx
+++ b/frontend/src/components/student-portal/nav-bar/NavBar.Component.jsx
@@ -55,7 +55,7 @@ function NavBar({ isAdminPage = false, isGuest = false }) {
     if (!currentUser) {
         settings = ['Login', 'Sign Up'];
     } else {
-        settings = ['Profile', 'Logout'];
+        settings = ['Logout'];
     }
 
     const navigate = useNavigate();


### PR DESCRIPTION
Eliminate the profile option from the navigation settings in the navigation bar.